### PR TITLE
Task:delete タスクを削除できる

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -8,6 +8,7 @@ use App\Repositories\Contracts\TaskRepository;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Illuminate\Auth\Access\AuthorizationException;
 
 class TaskController extends Controller
 {
@@ -70,5 +71,24 @@ class TaskController extends Controller
         $taskData->categories()->attach($request->category_ids);
 
         return $task;
+    }
+
+    /**
+     * @param int $taskId
+     * @return resource
+     * @throws AuthorizationException
+     */
+    public function delete(int $taskId)
+    {
+        $userId = auth()->id();
+        $task = $this->taskRepository->find($taskId);
+
+        if ($userId !== $task->user_id) {
+            throw new AuthorizationException('Cannot delete yourself.');
+        }
+
+        $this->taskRepository->deleteTask($task);
+
+        return response([], 204);
     }
 }

--- a/app/Repositories/Contracts/TaskRepository.php
+++ b/app/Repositories/Contracts/TaskRepository.php
@@ -42,6 +42,14 @@ interface TaskRepository
     public function updateTask(Collection $data, int $userId, Task $task);
 
     /**
+     * タスクを削除する
+     *
+     * @param Task $task
+     * @return Task
+     */
+    public function deleteTask(Task $task);
+
+    /**
      * タスクをID検索する
      *
      * @param int $taskId

--- a/app/Repositories/Eloquent/TaskRepositoryEloquent.php
+++ b/app/Repositories/Eloquent/TaskRepositoryEloquent.php
@@ -49,6 +49,18 @@ class TaskRepositoryEloquent implements TaskRepository
     }
 
     /**
+     * @param Task $task
+     * @return Task
+     */
+    public function deleteTask(Task $task)
+    {
+        \DB::transaction(function () use ($task) {
+            $task->categories()->detach();
+            $task->delete();
+        });
+    }
+
+    /**
      * @param int $taskId
      * @return Task
      */

--- a/routes/api.php
+++ b/routes/api.php
@@ -27,4 +27,5 @@ $router->group(['prefix' => 'task'], function () use ($router) {
     $router->get('', 'TaskController@index')->name('task-index');
     $router->post('', 'TaskController@store')->name('task-store');
     $router->put('{taskId}', 'TaskController@update')->name('task-update');
+    $router->delete('{taskId}', 'TaskController@delete')->name('task-delete');
 });

--- a/tests/Feature/TaskControllerTest.php
+++ b/tests/Feature/TaskControllerTest.php
@@ -107,4 +107,20 @@ class TaskControllerTest extends TestCase
         $this->assertEquals($params['status'], $editedTask->status);
         $this->assertEquals($this->user->id, $editedTask->user_id);
     }
+
+    /**
+     * @test
+     */
+    public function タスク削除のテスト()
+    {
+        $task = factory(Task::class)->create([
+            'user_id' => $this->user->id,
+        ]);
+        $categories = factory(Category::class, 2)->create();
+        $res = $this->delete(route('task-delete', $task->id));
+
+        $res->assertStatus(204);
+
+        $this->assertNull(Task::find($task->id));
+    }
 }


### PR DESCRIPTION
draft
差分をわかりやすくするため、task-putのPRに向いています